### PR TITLE
do not require nova 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.0",
-        "laravel/nova": "2.*"
+        "php": ">=7.1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As far as I can tell, this is working on nova 3.x without any additional changes